### PR TITLE
Support for SynchronousFlush and RetryOnError

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ These keys are relevant when using either SigningKey or Service identities
 | Debug              | Shows request details when set to true               | HSDP\_DEBUG                  | Optional |
 | CustomField        | Adds the field hash to custom field when set to true | HSDP\_CUSTOM\_FIELD          | Optional |
 | InsecureSkipVerify | Skip checking HSDP ingestor TLS cert. Insecure!      | HSDP\_INSECURE\_SKIP\_VERIFY | Optional |
-| SynchronousFlush   | Flushes log messages synchronously without batching  |                              | Optional |
-| RetryOnError       | Returns retry to FLB if flush fails. Applicable only when *SynchronousFlush* option is set | | Optional | 
+| SynchronousFlush   | Flushes log messages synchronously without batching. By default this is set to *false*  |   | Optional |
+| RetryOnError       | Returns retry to FLB if flush fails. Applicable only when *SynchronousFlush* option is set. By default this is set to *false* | | Optional | 
 
 ### Signing keys
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ These keys are relevant when using either SigningKey or Service identities
 | Debug              | Shows request details when set to true               | HSDP\_DEBUG                  | Optional |
 | CustomField        | Adds the field hash to custom field when set to true | HSDP\_CUSTOM\_FIELD          | Optional |
 | InsecureSkipVerify | Skip checking HSDP ingestor TLS cert. Insecure!      | HSDP\_INSECURE\_SKIP\_VERIFY | Optional |
+| SynchronousFlush   | Flushes log messages synchronously without batching  |                              | Optional |
+| RetryOnError       | Returns retry to FLB if flush fails. Applicable only when *SynchronousFlush* option is set | | Optional | 
 
 ### Signing keys
 


### PR DESCRIPTION
Added support for "SynchronousFlush" and "RetryOnError" based on configuration.

1.  When SynchronousFlush is set, call HSP logging service is made in the fluent-bit callback routine itself without pushing it to a background queue. This enables us to return FLB_RETRY error code back to fluent-bit in case of flush failures.  Without this flag, the current behavior of pushing the messages to a queue and sending them once we have batch of 25 messages continues.

2. When RetryOnError is set, FLB_RETRY error code is returned to fluent-bit when a flush error occurs. Without this, the current behavior of returning FLB_OK continues.